### PR TITLE
No need for ports

### DIFF
--- a/cerbos/compile.sh
+++ b/cerbos/compile.sh
@@ -1,4 +1,4 @@
-docker run -i -t -p 9999:9999 \
+docker run -i -t \
 -v $(pwd)/policies:/policies \
 -v $(pwd)/tests:/tests \
 ghcr.io/cerbos/cerbos:0.0.0-alpha3 \


### PR DESCRIPTION
According to https://github.com/cerbos/cerbos-private/issues/20 there is no need for the port to be live for compiler.
