### PR TITLE
chore: Retrieve latest cerbos version from github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project showcases using Cerbos inside of a GraphQL server. The server is wr
 ## Setup
 
 - Have Node v12+ on your machine (recommend using NVM)
-- Ensure your Docker is setup to pull `ghcr.io/cerbos/cerbos:0.8.0`
+- Ensure your Docker is setup to pull `ghcr.io/cerbos/cerbos:0.10.0`
 - Run `npm install` to get the node dependencies.
 
 ## Running
@@ -30,9 +30,11 @@ Once running, you can access GraphQL Playground [http://localhost:5000/graphql](
 - Finance can approve all invoices
 
 ## Sample Queries
+
 To run these you need to set an HTTP header called `token` which identifies the user (and thus there permissions)
 
 Some exampe tokens:
+
 - `key:sajit:it` is an IT Admin
 - `key:joe:finance` is an EMEA Finance person
 - `key:sally:sales` is an EMEA Sales person
@@ -62,6 +64,7 @@ Some exampe tokens:
 ```
 
 ### Approve an Expense
+
 ```
 mutation {
   approveExpense(id: "expense1")
@@ -76,5 +79,7 @@ mutation {
 </a>
 
 ## Playground
+
 Launch the policy from this demo in our playground. Play with it to see how Cerbos behaves.
+
 <P><a href="https://play.cerbos.dev/p/XhkOi82fFKk3YW60e2c806Yvm0trKEje"><img src="https://github.com/cerbos/express-jwt-cerbos/blob/main/docs/launch.jpg"></a></p>

--- a/cerbos/Dockerfile
+++ b/cerbos/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/cerbos/cerbos:0.8.0
+FROM ghcr.io/cerbos/cerbos:0.10.0
 LABEL org.opencontainers.image.source https://github.com/cerbos/demo-graphql
 COPY /policies /policies

--- a/cerbos/compile.sh
+++ b/cerbos/compile.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/cerbos/cerbos/releases/latest" | jq -r .tag_name)
+
 docker run -i -t \
 -v $(pwd)/policies:/policies \
-ghcr.io/cerbos/cerbos:0.8.0 \
+ghcr.io/cerbos/cerbos:"${LATEST_VERSION:1}" \
 compile /policies

--- a/cerbos/start.sh
+++ b/cerbos/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/cerbos/cerbos/releases/latest" | jq -r .tag_name)
+
 docker run -i -t -p 3592:3592 \
   -v $(pwd)/policies:/policies \
-  ghcr.io/cerbos/cerbos:0.8.0
+  ghcr.io/cerbos/cerbos:"${LATEST_VERSION:1}"


### PR DESCRIPTION
Signed-off-by: Oğuzhan D <oguzhandurgun95@gmail.com>

#### Description

Retrieves the latest release from GitHub API to use in scripts.

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
